### PR TITLE
Automatically select the ideal number of clusters for k-means clustering

### DIFF
--- a/Get-TextEmbeddingsUsingOpenAI.ps1
+++ b/Get-TextEmbeddingsUsingOpenAI.ps1
@@ -3311,7 +3311,7 @@ $queueLaggingTimestamps = New-Object System.Collections.Queue
 $queueLaggingTimestamps.Enqueue($timedateStartOfLoop)
 #endregion Collect Stats/Objects Needed for Writing Progress ##########################
 
-Write-Information ($strProgressActivity + ': ' + $strProgressStatus + '...')
+Write-Information ($strProgressActivity + '...')
 
 for ($intRowIndex = 0; $intRowIndex -lt $arrInputCSV.Count; $intRowIndex++) {
     #region Report Progress ########################################################

--- a/Get-TextEmbeddingsUsingOpenAI.ps1
+++ b/Get-TextEmbeddingsUsingOpenAI.ps1
@@ -1,5 +1,5 @@
 # Get-TextEmbeddingsUsingOpenAI.ps1
-# Version: 1.1.20240407.0
+# Version: 1.1.20240428.0
 
 <#
 .SYNOPSIS
@@ -3214,7 +3214,7 @@ if ($boolResult -eq $false) {
 
 #region Check for PowerShell module updates ########################################
 if ($DoNotCheckForModuleUpdates.IsPresent -eq $false) {
-    Write-Verbose 'Checking for module updates...'
+    Write-Information 'Checking for module updates...'
     $hashtableCustomNotUpToDateMessageToModuleNames = @{}
 
     $strAzNotUpToDateMessage = 'A newer version of the Az.Accounts and/or Az.KeyVault modules was found. Please consider updating it by running the following command:' + [System.Environment]::NewLine + 'Install-Module Az -Force;' + [System.Environment]::NewLine + [System.Environment]::NewLine + 'If the installation command fails, you may need to upgrade the version of PowerShellGet. To do so, run the following commands, then restart PowerShell:' + [System.Environment]::NewLine + 'Set-ExecutionPolicy Bypass -Scope Process -Force;' + [System.Environment]::NewLine + '[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;' + [System.Environment]::NewLine + 'Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force;' + [System.Environment]::NewLine + 'Install-Module PowerShellGet -MinimumVersion 2.2.4 -SkipPublisherCheck -Force -AllowClobber;' + [System.Environment]::NewLine + [System.Environment]::NewLine
@@ -3311,7 +3311,7 @@ $queueLaggingTimestamps = New-Object System.Collections.Queue
 $queueLaggingTimestamps.Enqueue($timedateStartOfLoop)
 #endregion Collect Stats/Objects Needed for Writing Progress ##########################
 
-Write-Verbose ($strProgressStatus + '...')
+Write-Information ($strProgressActivity + ': ' + $strProgressStatus + '...')
 
 for ($intRowIndex = 0; $intRowIndex -lt $arrInputCSV.Count; $intRowIndex++) {
     #region Report Progress ########################################################

--- a/Get-TopicForEachCluster.ps1
+++ b/Get-TopicForEachCluster.ps1
@@ -1,5 +1,5 @@
 # Get-TopicForEachCluster.ps1
-# Version: 1.0.20240407.0
+# Version: 1.0.20240428.0
 
 <#
 .SYNOPSIS
@@ -3795,6 +3795,12 @@ for ($intRowIndex = 0; $intRowIndex -lt $intTotalItems; $intRowIndex++) {
     }
     if ($OutputDataFromAllItemsInCluster -eq $true) {
         if ($arrTexts.Count -eq 0) {
+            $refCountOfItemsInCluster = [ref]((($arrClusterMetadataCSV[$intRowIndex]).PSObject.Properties | Where-Object { $_.MemberType -eq 'NoteProperty' -and $_.Name -eq $ClusterMetadataFieldNameCountOfItemsInCluster }).Value)
+            $refIndicesOfAllItemsInCluster = [ref]((($arrClusterMetadataCSV[$intRowIndex]).PSObject.Properties | Where-Object { $_.MemberType -eq 'NoteProperty' -and $_.Name -eq $ClusterMetadataFieldNameIndiciesOfAllItemsInCluster }).Value)
+
+            $intCountOfItemsInCluster = [int]($refCountOfItemsInCluster.Value)
+            $arrIndicesOfAllItemsInCluster = Split-StringOnLiteralString ($refIndicesOfAllItemsInCluster.Value) $ClusterMetadataIndicesSeparator
+
             for ($intCounterB = 0; $intCounterB -lt $intCountOfItemsInCluster; $intCounterB++) {
                 $intIndex = [int]($arrIndicesOfAllItemsInCluster[$intCounterB])
                 $arrTexts += (($arrUnstructuredTextDataCSV[$intIndex]).PSObject.Properties | Where-Object { $_.MemberType -eq 'NoteProperty' -and $_.Name -eq $UnstructuredTextDataFieldNameContainingTextData }).Value

--- a/Invoke-KMeansClustering.ps1
+++ b/Invoke-KMeansClustering.ps1
@@ -3146,7 +3146,10 @@ if ([string]::IsNullOrEmpty($OutputExcelWorkbookPathForClusterInformationForEach
 #region Select best number of clusters #############################################
 $PSCustomObjectTopCluster = $arrKeyStatistics | Sort-Object -Property 'CompositeRank' | Select-Object -First 1
 $intBestNumberOfClusters = $PSCustomObjectTopCluster.NumberOfClusters
-Write-Information ('Best number of clusters: ' + $intBestNumberOfClusters)
+if (($null -eq $NumberOfClusters) -or ($NumberOfClusters -le 0)) {
+    # Number of clusters was not specified
+    Write-Information ('Best number of clusters: ' + $intBestNumberOfClusters)
+}
 #endregion Select best number of clusters #############################################
 
 #region Generate output CSV for selected number of clusters ########################

--- a/Invoke-KMeansClustering.ps1
+++ b/Invoke-KMeansClustering.ps1
@@ -2747,14 +2747,16 @@ if ($null -ne $DoNotCalculateExtendedStatistics) {
 }
 
 # Display warning/information messages if necessary
-if ($boolDoNotCalculateExtendedStatistics -eq $true) {
-    Write-Warning 'The script is running without calculating the silhouette score, Davies-Bouldin index, and Calinski-Harabasz index; this will significantly speed up execution, but may lead to a less-ideal selection for the number of clusters.'
-    if (([string]::IsNullOrEmpty($OutputCSVPathForAllClusterStatistics) -eq $false) -and ([string]::IsNullOrEmpty($OutputExcelWorkbookPathForClusterInformationForEachNumberOfClusters) -eq $false)) {
-        Write-Warning 'Additionally, the script is working in unsupervised mode; it will do its best to select the best number of clusters and output the results to a CSV file, but no statistics and no Excel workbook that contains information about alternative numbers of clusters will be created. Combined with the fact that the silhouette score, Davies-Bouldin index, and Calinski-Harabasz index are not being calculated, running unsupervised in this manner is not a recommended mode of execution.'
-    }
-} else {
-    if (([string]::IsNullOrEmpty($OutputCSVPathForAllClusterStatistics) -eq $false) -and ([string]::IsNullOrEmpty($OutputExcelWorkbookPathForClusterInformationForEachNumberOfClusters) -eq $false)) {
-        Write-Information 'The script is working in unsupervised mode; it will automatically select the best number of clusters and output the results to a CSV file, but no statistics and no Excel workbook that contains information about alternative numbers of clusters will be created.'
+if (($null -ne $NumberOfClusters) -and ($NumberOfClusters -gt 0)) {
+    if ($boolDoNotCalculateExtendedStatistics -eq $true) {
+        Write-Warning 'The script is running without calculating the silhouette score, Davies-Bouldin index, and Calinski-Harabasz index; this will significantly speed up execution, but may lead to a less-ideal selection for the number of clusters.'
+        if (([string]::IsNullOrEmpty($OutputCSVPathForAllClusterStatistics) -eq $true) -and ([string]::IsNullOrEmpty($OutputExcelWorkbookPathForClusterInformationForEachNumberOfClusters) -eq $true)) {
+            Write-Warning 'Additionally, the script is working in unsupervised mode; it will do its best to select the best number of clusters and output the results to a CSV file, but no statistics and no Excel workbook that contains information about alternative numbers of clusters will be created. Combined with the fact that the silhouette score, Davies-Bouldin index, and Calinski-Harabasz index are not being calculated, running unsupervised in this manner is not a recommended mode of execution.'
+        }
+    } else {
+        if (([string]::IsNullOrEmpty($OutputCSVPathForAllClusterStatistics) -eq $true) -and ([string]::IsNullOrEmpty($OutputExcelWorkbookPathForClusterInformationForEachNumberOfClusters) -eq $true)) {
+            Write-Information 'The script is working in unsupervised mode; it will automatically select the best number of clusters and output the results to a CSV file, but no statistics and no Excel workbook that contains information about alternative numbers of clusters will be created.'
+        }
     }
 }
 

--- a/Invoke-KMeansClustering.ps1
+++ b/Invoke-KMeansClustering.ps1
@@ -2834,16 +2834,6 @@ if ($boolDoNotCalculateExtendedStatistics -eq $false) {
 }
 #endregion Rank the Calinski-Harabasz Index to bias toward higher values ##############
 
-#region Rank the Davies-Bouldin Index to bias toward lower values ##################
-Write-Debug 'Generating output CSV...'
-if ($versionPS -ge ([version]'6.0')) {
-    $listOutput = New-Object -TypeName 'System.Collections.Generic.List[PSCustomObject]'
-} else {
-    # On Windows PowerShell (versions older than 6.x), we use an ArrayList instead
-    # of a generic list
-}
-#endregion Rank the Davies-Bouldin Index to bias toward lower values ##################
-
 #region Generate composite ranking #################################################
 for ($intCounterA = 0; $intCounterA -le $intCounterAMax; $intCounterA++) {
     $doubleCompositeScore = [double]0
@@ -2920,6 +2910,11 @@ for ($intCounterA = 0; $intCounterA -le $intCounterAMax; $intCounterA++) {
     $arrKeyStatistics[$intCounterA] | Add-Member -MemberType NoteProperty -Name 'CompositeRank' -Value $doubleCompositeScore
 }
 #endregion Generate composite ranking #################################################
+
+#region Select best number of clusters #############################################
+$PSCustomObjectTopCluster = $arrKeyStatistics | Sort-Object -Property 'CompositeRank' | Select-Object -First 1
+
+#endregion Select best number of clusters #############################################
 
 return # temp
 

--- a/Invoke-KMeansClustering.ps1
+++ b/Invoke-KMeansClustering.ps1
@@ -76,7 +76,10 @@ param (
     [Parameter(Mandatory = $true)][string]$OutputCSVPath,
     [Parameter(Mandatory = $false)][int]$NSizeForMostRepresentativeDataPoints = 5,
     [Parameter(Mandatory = $false)][ValidateScript({ ($_ -ge 2) -or ($_ -eq 0) })][int]$NumberOfClusters,
-    [Parameter(Mandatory = $false)][switch]$DoNotCalculateExtendedStatistics
+    [Parameter(Mandatory = $false)][switch]$DoNotCalculateExtendedStatistics,
+    [Parameter(Mandatory = $false)][string]$OutputExcelWorkbookPathForAllClusterStatistics,
+    [Parameter(Mandatory = $false)][string]$OutputExcelWorkbookPathForAllClusters,
+    [Parameter(Mandatory = $false)][switch]$DoNotCheckForModuleUpdates
 )
 
 function Get-PSVersion {
@@ -245,6 +248,627 @@ function Split-StringOnLiteralString {
     } else {
         $result
     }
+}
+
+function Get-PowerShellModuleUsingHashtable {
+    <#
+    .SYNOPSIS
+    Gets a list of installed PowerShell modules for each entry in a hashtable.
+
+    .DESCRIPTION
+    The Get-PowerShellModuleUsingHashtable function steps through each entry in the
+    supplied hashtable and gets a list of installed PowerShell modules for each entry.
+
+    .PARAMETER ReferenceToHashtable
+    Is a reference to a hashtable. The value of the reference should be a hashtable
+    with keys that are the names of PowerShell modules and values that are initialized
+    to be enpty arrays.
+
+    .EXAMPLE
+    $hashtableModuleNameToInstalledModules = @{}
+    $hashtableModuleNameToInstalledModules.Add('PnP.PowerShell', @())
+    $hashtableModuleNameToInstalledModules.Add('Microsoft.Graph.Authentication', @())
+    $hashtableModuleNameToInstalledModules.Add('Microsoft.Graph.Groups', @())
+    $hashtableModuleNameToInstalledModules.Add('Microsoft.Graph.Users', @())
+    $refHashtableModuleNameToInstalledModules = [ref]$hashtableModuleNameToInstalledModules
+    Get-PowerShellModuleUsingHashtable -ReferenceToHashtable $refHashtableModuleNameToInstalledModules
+
+    This example gets the list of installed PowerShell modules for each of the four
+    modules listed in the hashtable. The list of each respective module is stored in
+    the value of the hashtable entry for that module.
+
+    .OUTPUTS
+    None
+    #>
+
+    #region License ################################################################
+    # Copyright (c) 2024 Frank Lesniak
+    #
+    # Permission is hereby granted, free of charge, to any person obtaining a copy of
+    # this software and associated documentation files (the "Software"), to deal in the
+    # Software without restriction, including without limitation the rights to use,
+    # copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+    # Software, and to permit persons to whom the Software is furnished to do so,
+    # subject to the following conditions:
+    #
+    # The above copyright notice and this permission notice shall be included in all
+    # copies or substantial portions of the Software.
+    #
+    # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    # FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+    # AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    #endregion License ################################################################
+
+    #region DownloadLocationNotice  ################################################
+    # The most up-to-date version of this script can be found on the author's GitHub
+    # repository at https://github.com/franklesniak/PowerShell_Resources
+    #endregion DownloadLocationNotice  ################################################
+
+    # Version 1.0.20240401.0
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)][ref]$ReferenceToHashtable
+    )
+
+    $VerbosePreferenceAtStartOfFunction = $VerbosePreference
+
+    $arrModulesToGet = @(($ReferenceToHashtable.Value).Keys)
+
+    for ($intCounter = 0; $intCounter -lt $arrModulesToGet.Count; $intCounter++) {
+        Write-Verbose ('Checking for ' + $arrModulesToGet[$intCounter] + ' module...')
+        $VerbosePreference = [System.Management.Automation.ActionPreference]::SilentlyContinue
+        ($ReferenceToHashtable.Value).Item($arrModulesToGet[$intCounter]) = @(Get-Module -Name ($arrModulesToGet[$intCounter]) -ListAvailable)
+        $VerbosePreference = $VerbosePreferenceAtStartOfFunction
+    }
+}
+
+function Test-PowerShellModuleInstalledUsingHashtable {
+    <#
+    .SYNOPSIS
+    Tests to see if a PowerShell module is installed based on entries in a hashtable.
+    If the PowerShell module is not installed, an error or warning message may
+    optionally be displayed.
+
+    .DESCRIPTION
+    The Test-PowerShellModuleInstalledUsingHashtable function steps through each entry
+    in the supplied hashtable and, if there are any modules not installed, it
+    optionally throws an error or warning for each module that is not installed. If all
+    modules are installed, the function returns $true; otherwise, if any module is not
+    installed, the function returns $false.
+
+    .PARAMETER ReferenceToHashtableOfInstalledModules
+    Is a reference to a hashtable. The hashtable must have keys that are the names of
+    PowerShell modules with each key's value populated with arrays of
+    ModuleInfoGrouping objects (the result of Get-Module).
+
+    .PARAMETER ThrowErrorIfModuleNotInstalled
+    Is a switch parameter. If this parameter is specified, an error is thrown for each
+    module that is not installed. If this parameter is not specified, no error is
+    thrown.
+
+    .PARAMETER ThrowWarningIfModuleNotInstalled
+    Is a switch parameter. If this parameter is specified, a warning is thrown for each
+    module that is not installed. If this parameter is not specified, or if the
+    ThrowErrorIfModuleNotInstalled parameter was specified, no warning is thrown.
+
+    .PARAMETER ReferenceToHashtableOfCustomNotInstalledMessages
+    Is a reference to a hashtable. The hashtable must have keys that are custom error
+    or warning messages (string) to be displayed if one or more modules are not
+    installed. The value for each key must be an array of PowerShell module names
+    (strings) relevant to that error or warning message.
+
+    If this parameter is not supplied, or if a custom error or warning message is not
+    supplied in the hashtable for a given module, the script will default to using the
+    following message:
+
+    <MODULENAME> module not found. Please install it and then try again.
+    You can install the <MODULENAME> PowerShell module from the PowerShell Gallery by
+    running the following command:
+    Install-Module <MODULENAME>;
+
+    If the installation command fails, you may need to upgrade the version of
+    PowerShellGet. To do so, run the following commands, then restart PowerShell:
+    Set-ExecutionPolicy Bypass -Scope Process -Force;
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
+    Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force;
+    Install-Module PowerShellGet -MinimumVersion 2.2.4 -SkipPublisherCheck -Force -AllowClobber;
+
+    .PARAMETER ReferenceToArrayOfMissingModules
+    Is a reference to an array. The array must be initialized to be empty. If any
+    modules are not installed, the names of those modules are added to the array.
+
+    .EXAMPLE
+    $hashtableModuleNameToInstalledModules = @{}
+    $hashtableModuleNameToInstalledModules.Add('PnP.PowerShell', @())
+    $hashtableModuleNameToInstalledModules.Add('Microsoft.Graph.Authentication', @())
+    $hashtableModuleNameToInstalledModules.Add('Microsoft.Graph.Groups', @())
+    $hashtableModuleNameToInstalledModules.Add('Microsoft.Graph.Users', @())
+    $refHashtableModuleNameToInstalledModules = [ref]$hashtableModuleNameToInstalledModules
+    Get-PowerShellModuleUsingHashtable -ReferenceToHashtable $refHashtableModuleNameToInstalledModules
+    $hashtableCustomNotInstalledMessageToModuleNames = @{}
+    $strGraphNotInstalledMessage = 'Microsoft.Graph.Authentication, Microsoft.Graph.Groups, and/or Microsoft.Graph.Users modules were not found. Please install the full Microsoft.Graph module and then try again.' + [System.Environment]::NewLine + 'You can install the Microsoft.Graph PowerShell module from the PowerShell Gallery by running the following command:' + [System.Environment]::NewLine + 'Install-Module Microsoft.Graph;' + [System.Environment]::NewLine + [System.Environment]::NewLine + 'If the installation command fails, you may need to upgrade the version of PowerShellGet. To do so, run the following commands, then restart PowerShell:' + [System.Environment]::NewLine + 'Set-ExecutionPolicy Bypass -Scope Process -Force;' + [System.Environment]::NewLine + '[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;' + [System.Environment]::NewLine + 'Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force;' + [System.Environment]::NewLine + 'Install-Module PowerShellGet -MinimumVersion 2.2.4 -SkipPublisherCheck -Force -AllowClobber;' + [System.Environment]::NewLine + [System.Environment]::NewLine
+    $hashtableCustomNotInstalledMessageToModuleNames.Add($strGraphNotInstalledMessage, @('Microsoft.Graph.Authentication', 'Microsoft.Graph.Groups', 'Microsoft.Graph.Users'))
+    $refhashtableCustomNotInstalledMessageToModuleNames = [ref]$hashtableCustomNotInstalledMessageToModuleNames
+    $boolResult = Test-PowerShellModuleInstalledUsingHashtable -ReferenceToHashtableOfInstalledModules $refHashtableModuleNameToInstalledModules -ThrowErrorIfModuleNotInstalled -ReferenceToHashtableOfCustomNotInstalledMessages $refhashtableCustomNotInstalledMessageToModuleNames
+
+    This example checks to see if the PnP.PowerShell, Microsoft.Graph.Authentication,
+    Microsoft.Graph.Groups, and Microsoft.Graph.Users modules are installed. If any of
+    these modules are not installed, an error is thrown for the PnP.PowerShell module
+    or the group of Microsoft.Graph modules, respectively, and $boolResult is set to
+    $false. If all modules are installed, $boolResult is set to $true.
+
+    .OUTPUTS
+    [boolean] - Returns $true if all modules are installed; otherwise, returns $false.
+    #>
+
+    #region License ################################################################
+    # Copyright (c) 2024 Frank Lesniak
+    #
+    # Permission is hereby granted, free of charge, to any person obtaining a copy of
+    # this software and associated documentation files (the "Software"), to deal in the
+    # Software without restriction, including without limitation the rights to use,
+    # copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+    # Software, and to permit persons to whom the Software is furnished to do so,
+    # subject to the following conditions:
+    #
+    # The above copyright notice and this permission notice shall be included in all
+    # copies or substantial portions of the Software.
+    #
+    # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    # FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+    # AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    #endregion License ################################################################
+
+    #region DownloadLocationNotice  ################################################
+    # The most up-to-date version of this script can be found on the author's GitHub
+    # repository at https://github.com/franklesniak/PowerShell_Resources
+    #endregion DownloadLocationNotice  ################################################
+
+    # Version 1.1.20240401.0
+
+    [CmdletBinding()]
+    [OutputType([Boolean])]
+    param (
+        [Parameter(Mandatory = $true)][ref]$ReferenceToHashtableOfInstalledModules,
+        [switch]$ThrowErrorIfModuleNotInstalled,
+        [switch]$ThrowWarningIfModuleNotInstalled,
+        [Parameter(Mandatory = $false)][ref]$ReferenceToHashtableOfCustomNotInstalledMessages,
+        [Parameter(Mandatory = $false)][ref]$ReferenceToArrayOfMissingModules
+    )
+
+    $boolThrowErrorForMissingModule = $false
+    $boolThrowWarningForMissingModule = $false
+
+    if ($ThrowErrorIfModuleNotInstalled.IsPresent -eq $true) {
+        $boolThrowErrorForMissingModule = $true
+    } elseif ($ThrowWarningIfModuleNotInstalled.IsPresent -eq $true) {
+        $boolThrowWarningForMissingModule = $true
+    }
+
+    $boolResult = $true
+
+    $hashtableMessagesToThrowForMissingModule = @{}
+    $hashtableModuleNameToCustomMessageToThrowForMissingModule = @{}
+    if ($null -ne $ReferenceToHashtableOfCustomNotInstalledMessages) {
+        $arrMessages = @(($ReferenceToHashtableOfCustomNotInstalledMessages.Value).Keys)
+        foreach ($strMessage in $arrMessages) {
+            $hashtableMessagesToThrowForMissingModule.Add($strMessage, $false)
+
+            ($ReferenceToHashtableOfCustomNotInstalledMessages.Value).Item($strMessage) | ForEach-Object {
+                $hashtableModuleNameToCustomMessageToThrowForMissingModule.Add($_, $strMessage)
+            }
+        }
+    }
+
+    $arrModuleNames = @(($ReferenceToHashtableOfInstalledModules.Value).Keys)
+    foreach ($strModuleName in $arrModuleNames) {
+        $arrInstalledModules = @(($ReferenceToHashtableOfInstalledModules.Value).Item($strModuleName))
+        if ($arrInstalledModules.Count -eq 0) {
+            $boolResult = $false
+
+            if ($hashtableModuleNameToCustomMessageToThrowForMissingModule.ContainsKey($strModuleName) -eq $true) {
+                $strMessage = $hashtableModuleNameToCustomMessageToThrowForMissingModule.Item($strModuleName)
+                $hashtableMessagesToThrowForMissingModule.Item($strMessage) = $true
+            } else {
+                $strMessage = $strModuleName + ' module not found. Please install it and then try again.' + [System.Environment]::NewLine + 'You can install the ' + $strModuleName + ' PowerShell module from the PowerShell Gallery by running the following command:' + [System.Environment]::NewLine + 'Install-Module ' + $strModuleName + ';' + [System.Environment]::NewLine + [System.Environment]::NewLine + 'If the installation command fails, you may need to upgrade the version of PowerShellGet. To do so, run the following commands, then restart PowerShell:' + [System.Environment]::NewLine + 'Set-ExecutionPolicy Bypass -Scope Process -Force;' + [System.Environment]::NewLine + '[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;' + [System.Environment]::NewLine + 'Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force;' + [System.Environment]::NewLine + 'Install-Module PowerShellGet -MinimumVersion 2.2.4 -SkipPublisherCheck -Force -AllowClobber;' + [System.Environment]::NewLine + [System.Environment]::NewLine
+                $hashtableMessagesToThrowForMissingModule.Add($strMessage, $true)
+            }
+
+            if ($null -ne $ReferenceToArrayOfMissingModules) {
+                ($ReferenceToArrayOfMissingModules.Value) += $strModuleName
+            }
+        }
+    }
+
+    if ($boolThrowErrorForMissingModule -eq $true) {
+        $arrMessages = @($hashtableMessagesToThrowForMissingModule.Keys)
+        foreach ($strMessage in $arrMessages) {
+            if ($hashtableMessagesToThrowForMissingModule.Item($strMessage) -eq $true) {
+                Write-Error $strMessage
+            }
+        }
+    } elseif ($boolThrowWarningForMissingModule -eq $true) {
+        $arrMessages = @($hashtableMessagesToThrowForMissingModule.Keys)
+        foreach ($strMessage in $arrMessages) {
+            if ($hashtableMessagesToThrowForMissingModule.Item($strMessage) -eq $true) {
+                Write-Warning $strMessage
+            }
+        }
+    }
+
+    return $boolResult
+}
+
+function Test-PowerShellModuleUpdatesAvailableUsingHashtable {
+    <#
+    .SYNOPSIS
+    Tests to see if updates are available for a PowerShell module based on entries in a
+    hashtable. If updates are available for a PowerShell module, an error or warning
+    message may optionally be displayed.
+
+    .DESCRIPTION
+    The Test-PowerShellModuleUpdatesAvailableUsingHashtable function steps through each
+    entry in the supplied hashtable and, if there are updates available, it optionally
+    throws an error or warning for each module that has updates available. If all
+    modules are installed and up to date, the function returns $true; otherwise, if any
+    module is not installed or not up to date, the function returns $false.
+
+    .PARAMETER ReferenceToHashtableOfInstalledModules
+    Is a reference to a hashtable. The hashtable must have keys that are the names of
+    PowerShell modules with each key's value populated with arrays of
+    ModuleInfoGrouping objects (the result of Get-Module).
+
+    .PARAMETER ThrowErrorIfModuleNotInstalled
+    Is a switch parameter. If this parameter is specified, an error is thrown for each
+    module that is not installed. If this parameter is not specified, no error is
+    thrown.
+
+    .PARAMETER ThrowWarningIfModuleNotInstalled
+    Is a switch parameter. If this parameter is specified, a warning is thrown for each
+    module that is not installed. If this parameter is not specified, or if the
+    ThrowErrorIfModuleNotInstalled parameter was specified, no warning is thrown.
+
+    .PARAMETER ThrowErrorIfModuleNotUpToDate
+    Is a switch parameter. If this parameter is specified, an error is thrown for each
+    module that is not up to date. If this parameter is not specified, no error is
+    thrown.
+
+    .PARAMETER ThrowWarningIfModuleNotUpToDate
+    Is a switch parameter. If this parameter is specified, a warning is thrown for each
+    module that is not up to date. If this parameter is not specified, or if the
+    ThrowErrorIfModuleNotUpToDate parameter was specified, no warning is thrown.
+
+    .PARAMETER ReferenceToHashtableOfCustomNotInstalledMessages
+    Is a reference to a hashtable. The hashtable must have keys that are custom error
+    or warning messages (string) to be displayed if one or more modules are not
+    installed. The value for each key must be an array of PowerShell module names
+    (strings) relevant to that error or warning message.
+
+    If this parameter is not supplied, or if a custom error or warning message is not
+    supplied in the hashtable for a given module, the script will default to using the
+    following message:
+
+    <MODULENAME> module not found. Please install it and then try again.
+    You can install the <MODULENAME> PowerShell module from the PowerShell Gallery by
+    running the following command:
+    Install-Module <MODULENAME>;
+
+    If the installation command fails, you may need to upgrade the version of
+    PowerShellGet. To do so, run the following commands, then restart PowerShell:
+    Set-ExecutionPolicy Bypass -Scope Process -Force;
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
+    Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force;
+    Install-Module PowerShellGet -MinimumVersion 2.2.4 -SkipPublisherCheck -Force -AllowClobber;
+
+    .PARAMETER ReferenceToHashtableOfCustomNotUpToDateMessages
+    Is a reference to a hashtable. The hashtable must have keys that are custom error
+    or warning messages (string) to be displayed if one or more modules are not
+    up to date. The value for each key must be an array of PowerShell module names
+    (strings) relevant to that error or warning message.
+
+    If this parameter is not supplied, or if a custom error or warning message is not
+    supplied in the hashtable for a given module, the script will default to using the
+    following message:
+
+    A newer version of the <MODULENAME> PowerShell module is available. Please consider
+    updating it by running the following command:
+    Install-Module <MODULENAME> -Force;
+
+    If the installation command fails, you may need to upgrade the version of
+    PowerShellGet. To do so, run the following commands, then restart PowerShell:
+    Set-ExecutionPolicy Bypass -Scope Process -Force;
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
+    Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force;
+    Install-Module PowerShellGet -MinimumVersion 2.2.4 -SkipPublisherCheck -Force -AllowClobber;
+
+    .PARAMETER ReferenceToArrayOfMissingModules
+    Is a reference to an array. The array must be initialized to be empty. If any
+    modules are not installed, the names of those modules are added to the array.
+
+    .PARAMETER ReferenceToArrayOfOutOfDateModules
+    Is a reference to an array. The array must be initialized to be empty. If any
+    modules are not up to date, the names of those modules are added to the array.
+
+    .EXAMPLE
+    $hashtableModuleNameToInstalledModules = @{}
+    $hashtableModuleNameToInstalledModules.Add('PnP.PowerShell', @())
+    $hashtableModuleNameToInstalledModules.Add('Microsoft.Graph.Authentication', @())
+    $hashtableModuleNameToInstalledModules.Add('Microsoft.Graph.Groups', @())
+    $hashtableModuleNameToInstalledModules.Add('Microsoft.Graph.Users', @())
+    $refHashtableModuleNameToInstalledModules = [ref]$hashtableModuleNameToInstalledModules
+    Get-PowerShellModuleUsingHashtable -ReferenceToHashtable $refHashtableModuleNameToInstalledModules
+    $hashtableCustomNotInstalledMessageToModuleNames = @{}
+    $strGraphNotInstalledMessage = 'Microsoft.Graph.Authentication, Microsoft.Graph.Groups, and/or Microsoft.Graph.Users modules were not found. Please install the full Microsoft.Graph module and then try again.' + [System.Environment]::NewLine + 'You can install the Microsoft.Graph PowerShell module from the PowerShell Gallery by running the following command:' + [System.Environment]::NewLine + 'Install-Module Microsoft.Graph;' + [System.Environment]::NewLine + [System.Environment]::NewLine + 'If the installation command fails, you may need to upgrade the version of PowerShellGet. To do so, run the following commands, then restart PowerShell:' + [System.Environment]::NewLine + 'Set-ExecutionPolicy Bypass -Scope Process -Force;' + [System.Environment]::NewLine + '[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;' + [System.Environment]::NewLine + 'Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force;' + [System.Environment]::NewLine + 'Install-Module PowerShellGet -MinimumVersion 2.2.4 -SkipPublisherCheck -Force -AllowClobber;' + [System.Environment]::NewLine + [System.Environment]::NewLine
+    $hashtableCustomNotInstalledMessageToModuleNames.Add($strGraphNotInstalledMessage, @('Microsoft.Graph.Authentication', 'Microsoft.Graph.Groups', 'Microsoft.Graph.Users'))
+    $refhashtableCustomNotInstalledMessageToModuleNames = [ref]$hashtableCustomNotInstalledMessageToModuleNames
+    $hashtableCustomNotUpToDateMessageToModuleNames = @{}
+    $strGraphNotUpToDateMessage = 'A newer version of the Microsoft.Graph.Authentication, Microsoft.Graph.Groups, and/or Microsoft.Graph.Users modules was found. Please consider updating it by running the following command:' + [System.Environment]::NewLine + 'Install-Module Microsoft.Graph -Force;' + [System.Environment]::NewLine + [System.Environment]::NewLine + 'If the installation command fails, you may need to upgrade the version of PowerShellGet. To do so, run the following commands, then restart PowerShell:' + [System.Environment]::NewLine + 'Set-ExecutionPolicy Bypass -Scope Process -Force;' + [System.Environment]::NewLine + '[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;' + [System.Environment]::NewLine + 'Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force;' + [System.Environment]::NewLine + 'Install-Module PowerShellGet -MinimumVersion 2.2.4 -SkipPublisherCheck -Force -AllowClobber;' + [System.Environment]::NewLine + [System.Environment]::NewLine
+    $hashtableCustomNotUpToDateMessageToModuleNames.Add($strGraphNotUpToDateMessage, @('Microsoft.Graph.Authentication', 'Microsoft.Graph.Groups', 'Microsoft.Graph.Users'))
+    $refhashtableCustomNotUpToDateMessageToModuleNames = [ref]$hashtableCustomNotUpToDateMessageToModuleNames
+    $boolResult = Test-PowerShellModuleUpdatesAvailableUsingHashtable -ReferenceToHashtableOfInstalledModules $refHashtableModuleNameToInstalledModules -ThrowErrorIfModuleNotInstalled -ThrowWarningIfModuleNotUpToDate -ReferenceToHashtableOfCustomNotInstalledMessages $refhashtableCustomNotInstalledMessageToModuleNames -ReferenceToHashtableOfCustomNotUpToDateMessages $refhashtableCustomNotUpToDateMessageToModuleNames
+
+    This example checks to see if the PnP.PowerShell, Microsoft.Graph.Authentication,
+    Microsoft.Graph.Groups, and Microsoft.Graph.Users modules are installed. If any of
+    these modules are not installed, an error is thrown for the PnP.PowerShell module
+    or the group of Microsoft.Graph modules, respectively, and $boolResult is set to
+    $false. If any of these modules are installed but not up to date, a warning
+    message is thrown for the PnP.PowerShell module or the group of Microsoft.Graph
+    modules, respectively, and $boolResult is set to false. If all modules are
+    installed and up to date, $boolResult is set to $true.
+
+    .OUTPUTS
+    [boolean] - Returns $true if all modules are installed and up to date; otherwise,
+    returns $false.
+
+    .NOTES
+    Requires PowerShell v5.0 or newer
+    #>
+
+    #region License ################################################################
+    # Copyright (c) 2024 Frank Lesniak
+    #
+    # Permission is hereby granted, free of charge, to any person obtaining a copy of
+    # this software and associated documentation files (the "Software"), to deal in the
+    # Software without restriction, including without limitation the rights to use,
+    # copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+    # Software, and to permit persons to whom the Software is furnished to do so,
+    # subject to the following conditions:
+    #
+    # The above copyright notice and this permission notice shall be included in all
+    # copies or substantial portions of the Software.
+    #
+    # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    # FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+    # AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    #endregion License ################################################################
+
+    #region DownloadLocationNotice  ################################################
+    # The most up-to-date version of this script can be found on the author's GitHub
+    # repository at https://github.com/franklesniak/PowerShell_Resources
+    #endregion DownloadLocationNotice  ################################################
+
+    # Version 1.1.20240401.0
+
+    [CmdletBinding()]
+    [OutputType([Boolean])]
+    param (
+        [Parameter(Mandatory = $true)][ref]$ReferenceToHashtableOfInstalledModules,
+        [switch]$ThrowErrorIfModuleNotInstalled,
+        [switch]$ThrowWarningIfModuleNotInstalled,
+        [switch]$ThrowErrorIfModuleNotUpToDate,
+        [switch]$ThrowWarningIfModuleNotUpToDate,
+        [Parameter(Mandatory = $false)][ref]$ReferenceToHashtableOfCustomNotInstalledMessages,
+        [Parameter(Mandatory = $false)][ref]$ReferenceToHashtableOfCustomNotUpToDateMessages,
+        [Parameter(Mandatory = $false)][ref]$ReferenceToArrayOfMissingModules,
+        [Parameter(Mandatory = $false)][ref]$ReferenceToArrayOfOutdatedModules
+    )
+
+    function Get-PSVersion {
+        # Returns the version of PowerShell that is running, including on the original
+        # release of Windows PowerShell (version 1.0)
+        #
+        # Example:
+        # Get-PSVersion
+        #
+        # This example returns the version of PowerShell that is running. On versions
+        # of PowerShell greater than or equal to version 2.0, this function returns the
+        # equivalent of $PSVersionTable.PSVersion
+        #
+        # The function outputs a [version] object representing the version of
+        # PowerShell that is running
+        #
+        # PowerShell 1.0 does not have a $PSVersionTable variable, so this function
+        # returns [version]('1.0') on PowerShell 1.0
+
+        #region License ############################################################
+        # Copyright (c) 2024 Frank Lesniak
+        #
+        # Permission is hereby granted, free of charge, to any person obtaining a copy
+        # of this software and associated documentation files (the "Software"), to deal
+        # in the Software without restriction, including without limitation the rights
+        # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        # copies of the Software, and to permit persons to whom the Software is
+        # furnished to do so, subject to the following conditions:
+        #
+        # The above copyright notice and this permission notice shall be included in
+        # all copies or substantial portions of the Software.
+        #
+        # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+        # SOFTWARE.
+        #endregion License ############################################################
+
+        #region DownloadLocationNotice #############################################
+        # The most up-to-date version of this script can be found on the author's
+        # GitHub repository at https://github.com/franklesniak/PowerShell_Resources
+        #endregion DownloadLocationNotice #############################################
+
+        $versionThisFunction = [version]('1.0.20240326.0')
+
+        if (Test-Path variable:\PSVersionTable) {
+            return ($PSVersionTable.PSVersion)
+        } else {
+            return ([version]('1.0'))
+        }
+    }
+
+    $versionPS = Get-PSVersion
+    if ($versionPS -lt ([version]'5.0')) {
+        Write-Warning 'Test-PowerShellModuleUpdatesAvailableUsingHashtable requires PowerShell version 5.0 or newer.'
+        return $false
+    }
+
+    $boolThrowErrorForMissingModule = $false
+    $boolThrowWarningForMissingModule = $false
+
+    if ($ThrowErrorIfModuleNotInstalled.IsPresent -eq $true) {
+        $boolThrowErrorForMissingModule = $true
+    } elseif ($ThrowWarningIfModuleNotInstalled.IsPresent -eq $true) {
+        $boolThrowWarningForMissingModule = $true
+    }
+
+    $boolThrowErrorForOutdatedModule = $false
+    $boolThrowWarningForOutdatedModule = $false
+
+    if ($ThrowErrorIfModuleNotUpToDate.IsPresent -eq $true) {
+        $boolThrowErrorForOutdatedModule = $true
+    } elseif ($ThrowWarningIfModuleNotUpToDate.IsPresent -eq $true) {
+        $boolThrowWarningForOutdatedModule = $true
+    }
+
+    $VerbosePreferenceAtStartOfFunction = $VerbosePreference
+
+    $boolResult = $true
+
+    $hashtableMessagesToThrowForMissingModule = @{}
+    $hashtableModuleNameToCustomMessageToThrowForMissingModule = @{}
+    if ($null -ne $ReferenceToHashtableOfCustomNotInstalledMessages) {
+        $arrMessages = @(($ReferenceToHashtableOfCustomNotInstalledMessages.Value).Keys)
+        foreach ($strMessage in $arrMessages) {
+            $hashtableMessagesToThrowForMissingModule.Add($strMessage, $false)
+
+            ($ReferenceToHashtableOfCustomNotInstalledMessages.Value).Item($strMessage) | ForEach-Object {
+                $hashtableModuleNameToCustomMessageToThrowForMissingModule.Add($_, $strMessage)
+            }
+        }
+    }
+
+    $hashtableMessagesToThrowForOutdatedModule = @{}
+    $hashtableModuleNameToCustomMessageToThrowForOutdatedModule = @{}
+    if ($null -ne $ReferenceToHashtableOfCustomNotUpToDateMessages) {
+        $arrMessages = @(($ReferenceToHashtableOfCustomNotUpToDateMessages.Value).Keys)
+        foreach ($strMessage in $arrMessages) {
+            $hashtableMessagesToThrowForOutdatedModule.Add($strMessage, $false)
+
+            ($ReferenceToHashtableOfCustomNotUpToDateMessages.Value).Item($strMessage) | ForEach-Object {
+                $hashtableModuleNameToCustomMessageToThrowForOutdatedModule.Add($_, $strMessage)
+            }
+        }
+    }
+
+    $arrModuleNames = @(($ReferenceToHashtableOfInstalledModules.Value).Keys)
+    foreach ($strModuleName in $arrModuleNames) {
+        $arrInstalledModules = @(($ReferenceToHashtableOfInstalledModules.Value).Item($strModuleName))
+        if ($arrInstalledModules.Count -eq 0) {
+            $boolResult = $false
+
+            if ($hashtableModuleNameToCustomMessageToThrowForMissingModule.ContainsKey($strModuleName) -eq $true) {
+                $strMessage = $hashtableModuleNameToCustomMessageToThrowForMissingModule.Item($strModuleName)
+                $hashtableMessagesToThrowForMissingModule.Item($strMessage) = $true
+            } else {
+                $strMessage = $strModuleName + ' module not found. Please install it and then try again.' + [System.Environment]::NewLine + 'You can install the ' + $strModuleName + ' PowerShell module from the PowerShell Gallery by running the following command:' + [System.Environment]::NewLine + 'Install-Module ' + $strModuleName + ';' + [System.Environment]::NewLine + [System.Environment]::NewLine + 'If the installation command fails, you may need to upgrade the version of PowerShellGet. To do so, run the following commands, then restart PowerShell:' + [System.Environment]::NewLine + 'Set-ExecutionPolicy Bypass -Scope Process -Force;' + [System.Environment]::NewLine + '[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;' + [System.Environment]::NewLine + 'Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force;' + [System.Environment]::NewLine + 'Install-Module PowerShellGet -MinimumVersion 2.2.4 -SkipPublisherCheck -Force -AllowClobber;' + [System.Environment]::NewLine + [System.Environment]::NewLine
+                $hashtableMessagesToThrowForMissingModule.Add($strMessage, $true)
+            }
+
+            if ($null -ne $ReferenceToArrayOfMissingModules) {
+                ($ReferenceToArrayOfMissingModules.Value) += $strModuleName
+            }
+        } else {
+            $versionNewestInstalledModule = ($arrInstalledModules | ForEach-Object { [version]($_.Version) } | Sort-Object)[-1]
+
+            $arrModuleNewestInstalledModule = @($arrInstalledModules | Where-Object { ([version]($_.Version)) -eq $versionNewestInstalledModule })
+
+            # In the event there are multiple installations of the same version, reduce to a
+            # single instance of the module
+            if ($arrModuleNewestInstalledModule.Count -gt 1) {
+                $moduleNewestInstalled = @($arrModuleNewestInstalledModule | Select-Object -Unique)[0]
+            } else {
+                $moduleNewestInstalled = $arrModuleNewestInstalledModule[0]
+            }
+
+            $VerbosePreference = [System.Management.Automation.ActionPreference]::SilentlyContinue
+            $moduleNewestAvailable = Find-Module -Name $strModuleName -ErrorAction SilentlyContinue
+            $VerbosePreference = $VerbosePreferenceAtStartOfFunction
+
+            if ($null -ne $moduleNewestAvailable) {
+                if ($moduleNewestAvailable.Version -gt $moduleNewestInstalled.Version) {
+                    # A newer version is available
+                    $boolResult = $false
+
+                    if ($hashtableModuleNameToCustomMessageToThrowForOutdatedModule.ContainsKey($strModuleName) -eq $true) {
+                        $strMessage = $hashtableModuleNameToCustomMessageToThrowForOutdatedModule.Item($strModuleName)
+                        $hashtableMessagesToThrowForOutdatedModule.Item($strMessage) = $true
+                    } else {
+                        $strMessage = 'A newer version of the ' + $strModuleName + ' PowerShell module is available. Please consider updating it by running the following command:' + [System.Environment]::NewLine + 'Install-Module ' + $strModuleName + ' -Force;' + [System.Environment]::NewLine + [System.Environment]::NewLine + 'If the installation command fails, you may need to upgrade the version of PowerShellGet. To do so, run the following commands, then restart PowerShell:' + [System.Environment]::NewLine + 'Set-ExecutionPolicy Bypass -Scope Process -Force;' + [System.Environment]::NewLine + '[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;' + [System.Environment]::NewLine + 'Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force;' + [System.Environment]::NewLine + 'Install-Module PowerShellGet -MinimumVersion 2.2.4 -SkipPublisherCheck -Force -AllowClobber;' + [System.Environment]::NewLine + [System.Environment]::NewLine
+                        $hashtableMessagesToThrowForOutdatedModule.Add($strMessage, $true)
+                    }
+
+                    if ($null -ne $ReferenceToArrayOfOutdatedModules) {
+                        ($ReferenceToArrayOfOutdatedModules.Value) += $strModuleName
+                    }
+                }
+            } else {
+                # Couldn't find the module in the PowerShell Gallery
+            }
+        }
+    }
+
+    if ($boolThrowErrorForMissingModule -eq $true) {
+        $arrMessages = @($hashtableMessagesToThrowForMissingModule.Keys)
+        foreach ($strMessage in $arrMessages) {
+            if ($hashtableMessagesToThrowForMissingModule.Item($strMessage) -eq $true) {
+                Write-Error $strMessage
+            }
+        }
+    } elseif ($boolThrowWarningForMissingModule -eq $true) {
+        $arrMessages = @($hashtableMessagesToThrowForMissingModule.Keys)
+        foreach ($strMessage in $arrMessages) {
+            if ($hashtableMessagesToThrowForMissingModule.Item($strMessage) -eq $true) {
+                Write-Warning $strMessage
+            }
+        }
+    }
+
+    if ($boolThrowErrorForOutdatedModule -eq $true) {
+        $arrMessages = @($hashtableMessagesToThrowForOutdatedModule.Keys)
+        foreach ($strMessage in $arrMessages) {
+            if ($hashtableMessagesToThrowForOutdatedModule.Item($strMessage) -eq $true) {
+                Write-Error $strMessage
+            }
+        }
+    } elseif ($boolThrowWarningForOutdatedModule -eq $true) {
+        $arrMessages = @($hashtableMessagesToThrowForOutdatedModule.Keys)
+        foreach ($strMessage in $arrMessages) {
+            if ($hashtableMessagesToThrowForOutdatedModule.Item($strMessage) -eq $true) {
+                Write-Warning $strMessage
+            }
+        }
+    }
+    return $boolResult
 }
 
 function Test-NuGetDotOrgRegisteredAsPackageSource {
@@ -1257,6 +1881,61 @@ function Invoke-KMeansClusteringForSpecifiedNumberOfClusters {
         [Parameter(Mandatory = $true)][switch]$DoNotCalculateExtendedStatistics
     )
 
+    function Get-PSVersion {
+        # Returns the version of PowerShell that is running, including on the original
+        # release of Windows PowerShell (version 1.0)
+        #
+        # Example:
+        # Get-PSVersion
+        #
+        # This example returns the version of PowerShell that is running. On versions
+        # of PowerShell greater than or equal to version 2.0, this function returns the
+        # equivalent of $PSVersionTable.PSVersion
+        #
+        # The function outputs a [version] object representing the version of
+        # PowerShell that is running
+        #
+        # PowerShell 1.0 does not have a $PSVersionTable variable, so this function
+        # returns [version]('1.0') on PowerShell 1.0
+
+        #region License ############################################################
+        # Copyright (c) 2024 Frank Lesniak
+        #
+        # Permission is hereby granted, free of charge, to any person obtaining a copy
+        # of this software and associated documentation files (the "Software"), to deal
+        # in the Software without restriction, including without limitation the rights
+        # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        # copies of the Software, and to permit persons to whom the Software is
+        # furnished to do so, subject to the following conditions:
+        #
+        # The above copyright notice and this permission notice shall be included in
+        # all copies or substantial portions of the Software.
+        #
+        # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+        # SOFTWARE.
+        #endregion License ############################################################
+
+        #region DownloadLocationNotice #############################################
+        # The most up-to-date version of this script can be found on the author's
+        # GitHub repository at https://github.com/franklesniak/PowerShell_Resources
+        #endregion DownloadLocationNotice #############################################
+
+        $versionThisFunction = [version]('1.0.20240326.0')
+
+        if (Test-Path variable:\PSVersionTable) {
+            return ($PSVersionTable.PSVersion)
+        } else {
+            return ([version]('1.0'))
+        }
+    }
+
+    $versionPS = Get-PSVersion
+
     if (($ReferenceToHashtableOfNumberOfClustersToArtifacts.Value).ContainsKey($NumberOfClusters) -eq $true) {
         # The specified number of clusters has already been processed
         return
@@ -1697,13 +2376,6 @@ function Invoke-KMeansClusteringForSpecifiedNumberOfClusters {
 
 $versionPS = Get-PSVersion
 
-$boolDoNotCalculateExtendedStatistics = $false
-if ($null -ne $DoNotCalculateExtendedStatistics) {
-    if ($DoNotCalculateExtendedStatistics.IsPresent -eq $true) {
-        $boolDoNotCalculateExtendedStatistics = $true
-    }
-}
-
 #region Quit if PowerShell Version is Unsupported ##################################
 if ($versionPS -lt [version]'5.0') {
     Write-Warning 'This script requires PowerShell v5.0 or higher. Please upgrade to PowerShell v5.0 or higher and try again.'
@@ -1711,18 +2383,62 @@ if ($versionPS -lt [version]'5.0') {
 }
 #endregion Quit if PowerShell Version is Unsupported ##################################
 
-# Make sure the input file exists
+#region Check for required PowerShell Modules ######################################
+if (([string]::IsNullOrEmpty($OutputExcelWorkbookPathForAllClusterStatistics) -eq $false) -or ([string]::IsNullOrEmpty($OutputExcelWorkbookPathForAllClusters) -eq $false)) {
+    # User has requested at least one Excel workbook; make sure ImportExcel is
+    # installed
+    $hashtableModuleNameToInstalledModules = @{}
+    $hashtableModuleNameToInstalledModules.Add('ImportExcel', @())
+    $refHashtableModuleNameToInstalledModules = [ref]$hashtableModuleNameToInstalledModules
+    Get-PowerShellModuleUsingHashtable -ReferenceToHashtable $refHashtableModuleNameToInstalledModules
+
+    $hashtableCustomNotInstalledMessageToModuleNames = @{}
+
+    $refhashtableCustomNotInstalledMessageToModuleNames = [ref]$hashtableCustomNotInstalledMessageToModuleNames
+    $boolResult = Test-PowerShellModuleInstalledUsingHashtable -ReferenceToHashtableOfInstalledModules $refHashtableModuleNameToInstalledModules -ThrowErrorIfModuleNotInstalled -ReferenceToHashtableOfCustomNotInstalledMessages $refhashtableCustomNotInstalledMessageToModuleNames
+
+    if ($boolResult -eq $false) {
+        return # Quit script
+    }
+}
+#endregion Check for required PowerShell Modules ######################################
+
+#region Check for PowerShell module updates ########################################
+if (([string]::IsNullOrEmpty($OutputExcelWorkbookPathForAllClusterStatistics) -eq $false) -or ([string]::IsNullOrEmpty($OutputExcelWorkbookPathForAllClusters) -eq $false)) {
+    # User has requested at least one Excel workbook; make sure ImportExcel is
+    # up to date
+    $boolDoNotCheckForModuleUpdates = $false
+    if ($null -ne $DoNotCheckForModuleUpdates) {
+        if ($DoNotCheckForModuleUpdates.IsPresent -eq $true) {
+            $boolDoNotCheckForModuleUpdates = $true
+        }
+    }
+    if ($boolDoNotCheckForModuleUpdates -eq $false) {
+        Write-Verbose 'Checking for module updates...'
+        $hashtableCustomNotUpToDateMessageToModuleNames = @{}
+
+        $refhashtableCustomNotUpToDateMessageToModuleNames = [ref]$hashtableCustomNotUpToDateMessageToModuleNames
+        $boolResult = Test-PowerShellModuleUpdatesAvailableUsingHashtable -ReferenceToHashtableOfInstalledModules $refHashtableModuleNameToInstalledModules -ThrowErrorIfModuleNotInstalled -ThrowWarningIfModuleNotUpToDate -ReferenceToHashtableOfCustomNotInstalledMessages $refhashtableCustomNotInstalledMessageToModuleNames -ReferenceToHashtableOfCustomNotUpToDateMessages $refhashtableCustomNotUpToDateMessageToModuleNames
+    }
+}
+#endregion Check for PowerShell module updates ########################################
+
+#region Make sure the input file exists ############################################
 if ((Test-Path -Path $InputCSVPath -PathType Leaf) -eq $false) {
     Write-Warning ('Input CSV file not found at: "' + $InputCSVPath + '"')
     return # Quit script
 }
+#endregion Make sure the input file exists ############################################
 
-# Make sure that nuget.org is registered as a package source; if not, throw a warning and quit
+#region Make sure that nuget.org is registered as a package source #################
+# (if not, throw a warning and quit)
 $boolNuGetDotOrgRegisteredAsPackageSource = Test-NuGetDotOrgRegisteredAsPackageSource -ThrowWarningIfNuGetDotOrgNotRegistered
 if ($boolNuGetDotOrgRegisteredAsPackageSource -eq $false) {
     return # Quit script
 }
+#endregion Make sure that nuget.org is registered as a package source #################
 
+#region Make sure that required NuGet packages are installed #######################
 $hashtablePackageNameToInstalledPackageMetadata = @{}
 
 $hashtablePackageNameToInstalledPackageMetadata.Add('Accord', $null)
@@ -1744,9 +2460,10 @@ $boolResult = Test-PackageInstalledUsingHashtable -ReferenceToHashtableOfInstall
 if ($boolResult -eq $false) {
     return # Quit script
 }
+#endregion Make sure that required NuGet packages are installed #######################
 
-# Make sure the output file doesn't already exist and if it does, delete it and then
-# verify that it's gone
+#region Make sure the output file doesn't already exist ############################
+# (and if it does, delete it and then verify that it's gone)
 if ((Test-Path -Path $OutputCSVPath -PathType Leaf) -eq $true) {
     Remove-Item -Path $OutputCSVPath -Force
     if ((Test-Path -Path $OutputCSVPath -PathType Leaf) -eq $true) {
@@ -1754,14 +2471,16 @@ if ((Test-Path -Path $OutputCSVPath -PathType Leaf) -eq $true) {
         return
     }
 }
+#endregion Make sure the output file doesn't already exist ############################
 
-# Import the CSV
+#region Import the CSV #############################################################
 $arrInputCSV = @()
 $arrInputCSV = @(Import-Csv $InputCSVPath)
 if ($arrInputCSV.Count -eq 0) {
     Write-Warning ('Input CSV file is empty: "' + $InputCSVPath + '"')
     return
 }
+#endregion Import the CSV #############################################################
 
 # Create a fixed-size array to store the embeddings
 $arrEmbeddings = New-Object PSCustomObject[] $arrInputCSV.Count
@@ -1851,7 +2570,7 @@ foreach ($strPackageName in $arrNuGetPackages) {
 }
 #endregion Load the Accord.NET NuGet Package DLLs #####################################
 
-# Determine upper and lower bounds for the number of clusters
+#region Determine upper and lower bounds for the number of clusters ################
 if (($null -eq $NumberOfClusters) -or ($NumberOfClusters -le 0)) {
     if ($arrInputCSV.Count -lt 1) {
         $intMinNumberOfClusters = $arrInputCSV.Count
@@ -1866,10 +2585,19 @@ if (($null -eq $NumberOfClusters) -or ($NumberOfClusters -le 0)) {
     $intMinNumberOfClusters = $NumberOfClusters
     $intMaxNumberOfClusters = $NumberOfClusters
 }
+#endregion Determine upper and lower bounds for the number of clusters ################
 
+#region Perform k-means clustering #################################################
 $hashtableKToClusterArtifacts = @{}
 $hashtableEuclideanDistancesBetweenItems = @{}
 $arrCentroidOverWholeDataset = @()
+
+$boolDoNotCalculateExtendedStatistics = $false
+if ($null -ne $DoNotCalculateExtendedStatistics) {
+    if ($DoNotCalculateExtendedStatistics.IsPresent -eq $true) {
+        $boolDoNotCalculateExtendedStatistics = $true
+    }
+}
 
 if ($intMinNumberOfClusters -ne 1) {
     if ($boolDoNotCalculateExtendedStatistics -eq $false) {
@@ -1902,6 +2630,31 @@ if ($intMinNumberOfClusters -ne 1) {
         }
     }
 }
+#endregion Perform k-means clustering #################################################
+
+#region Calculate WCSS first and second derivative #################################
+if ($boolDoNotCalculateExtendedStatistics -eq $false) {
+    $arrKeyStatistics = $hashtableKToClusterArtifacts.Values | Select-Object -Property @('NumberOfClusters', 'WithinClusterSumOfSquares', 'SilhouetteScore', 'DaviesBouldinIndex', 'CalinskiHarabaszIndex') | Sort-Object -Property 'NumberOfClusters'
+} else {
+    $arrKeyStatistics = $hashtableKToClusterArtifacts.Values | Select-Object -Property @('NumberOfClusters', 'WithinClusterSumOfSquares') | Sort-Object -Property 'NumberOfClusters'
+}
+$intCounterAMax = $arrKeyStatistics.Count - 1
+# Add WCSS first and second derivative properties to each object
+for ($intCounterA = 0; $intCounterA -le $intCounterAMax; $intCounterA++) {
+    $arrKeyStatistics[$intCounterA] | Add-Member -MemberType NoteProperty -Name 'WCSSFirstDerivative' -Value $null
+    $arrKeyStatistics[$intCounterA] | Add-Member -MemberType NoteProperty -Name 'WCSSSecondDerivative' -Value $null
+}
+# Calculate the first derivative
+for ($intCounterA = 1; $intCounterA -le $intCounterAMax; $intCounterA++) {
+    $doubleWCSSFirstDerivative = $arrKeyStatistics[$intCounterA].WithinClusterSumOfSquares - $arrKeyStatistics[$intCounterA - 1].WithinClusterSumOfSquares
+    $arrKeyStatistics[$intCounterA].WCSSFirstDerivative = $doubleWCSSFirstDerivative
+}
+# Calculate the second derivative
+for ($intCounterA = 2; $intCounterA -le $intCounterAMax; $intCounterA++) {
+    $doubleWCSSSecondDerivative = $arrKeyStatistics[$intCounterA].WCSSFirstDerivative - $arrKeyStatistics[$intCounterA - 1].WCSSFirstDerivative
+    $arrKeyStatistics[$intCounterA].WCSSSecondDerivative = $doubleWCSSSecondDerivative
+}
+#endregion Calculate WCSS first and second derivative #################################
 
 return # temp
 

--- a/Invoke-KMeansClustering.ps1
+++ b/Invoke-KMeansClustering.ps1
@@ -1884,7 +1884,7 @@ function Invoke-KMeansClusteringForSpecifiedNumberOfClusters {
         [Parameter(Mandatory = $true)][ref]$ReferenceToTwoDimensionalArrayOfEmbeddings,
         [Parameter(Mandatory = $true)][ref]$ReferenceToHashtableOfEuclideanDistancesBetweenItems,
         [Parameter(Mandatory = $true)][ref]$ReferenceToCentroidOverWholeDataset,
-        [Parameter(Mandatory = $true)][switch]$DoNotCalculateExtendedStatistics
+        [Parameter(Mandatory = $false)][switch]$DoNotCalculateExtendedStatistics
     )
 
     function Get-PSVersion {

--- a/Invoke-KMeansClustering.ps1
+++ b/Invoke-KMeansClustering.ps1
@@ -2764,6 +2764,7 @@ if ($intMinNumberOfClusters -ne 1) {
     if ($boolDoNotCalculateExtendedStatistics -eq $false) {
         # We need to run it once for a single cluster to get the centroid for the whole
         # data set
+        Write-Information ('Performing k-means clustering for 1 cluster to get the centroid for the whole dataset...')
         $hashtableKToClusterArtifactsTEMP = @{}
         Invoke-KMeansClusteringForSpecifiedNumberOfClusters -ReferenceToHashtableOfNumberOfClustersToArtifacts ([ref]$hashtableKToClusterArtifactsTEMP) -NumberOfClusters 1 -ReferenceToTwoDimensionalArrayOfEmbeddings ([ref]$arrEmbeddings) -ReferenceToHashtableOfEuclideanDistancesBetweenItems ([ref]$hashtableEuclideanDistancesBetweenItems) -ReferenceToCentroidOverWholeDataset ([ref]$arrCentroidOverWholeDataset)
     }

--- a/Invoke-KMeansClustering.ps1
+++ b/Invoke-KMeansClustering.ps1
@@ -79,7 +79,7 @@ yourself a few seconds by specifying this parameter.
 .PARAMETER WeightingFactorForNumberOfClusters
 Optional parameter; specifies the weighting factor to apply to the number of clusters
 when calculating the composite index for selecting the number of clusters. The default
-value is 8. The number of clusters is only weighted when the maximum silhouette score
+value is 14. The number of clusters is only weighted when the maximum silhouette score
 across all iterations is less than 0.4, indicating potential poor clustering. When this
 happens, the script biases toward selecting more clusters.
 
@@ -93,14 +93,14 @@ be low when the number of clusters is high, which can lead to "over-fitting".
 .PARAMETER WeightingFactorForWCSSSecondDerivative
 Optional parameter; specifies the weighting factor to apply to the second derivative of
 the Within-Cluster Sum of Squares (WCSS) when calculating the composite index for
-selecting the number of clusters. The default value is 42. The second derivative of the
+selecting the number of clusters. The default value is 40. The second derivative of the
 WCSS indicates the change in slope, so the highest second derivative may indicate the
 "elbow point" in the WCSS plot, which is used to select the number of clusters.
 
 .PARAMETER WeightingFactorForSihouetteScore
 Optional parameter; specifies the weighting factor to apply to the Silhouette Score when
 calculating the composite index for selecting the number of clusters. The default value
-is 23. The Silhouette Score is a measure of how similar an object is to its own cluster
+is 18. The Silhouette Score is a measure of how similar an object is to its own cluster
 compared to other clusters. Silhouette Scores range from -1 to 1, with a high value
 indicating that the object is well matched to its own cluster and poorly matched to
 neighboring clusters.
@@ -108,7 +108,7 @@ neighboring clusters.
 .PARAMETER WeightingFactorForDaviesBouldinScore
 Optional parameter; specifies the weighting factor to apply to the Davies-Bouldin Score
 when calculating the composite index for selecting the number of clusters. The default
-value is 12. The Davies-Bouldin Score is a measure of the average similarity between
+value is 13. The Davies-Bouldin Score is a measure of the average similarity between
 each cluster and its most similar cluster. The lower the score, the better the
 clustering.
 
@@ -169,11 +169,11 @@ param (
     [Parameter(Mandatory = $false)][ValidateScript({ ($_ -ge 2) -or ($_ -eq 0) })][int]$NumberOfClusters,
     [Parameter(Mandatory = $false)][switch]$DoNotCalculateExtendedStatistics,
     [Parameter(Mandatory = $false)][switch]$DoNotCheckForModuleUpdates,
-    [Parameter(Mandatory = $false)][double]$WeightingFactorForNumberOfClusters = 8,
+    [Parameter(Mandatory = $false)][double]$WeightingFactorForNumberOfClusters = 14,
     [Parameter(Mandatory = $false)][double]$WeightingFactorForWCSS = 3,
-    [Parameter(Mandatory = $false)][double]$WeightingFactorForWCSSSecondDerivative = 42,
-    [Parameter(Mandatory = $false)][double]$WeightingFactorForSihouetteScore = 23,
-    [Parameter(Mandatory = $false)][double]$WeightingFactorForDaviesBouldinScore = 12,
+    [Parameter(Mandatory = $false)][double]$WeightingFactorForWCSSSecondDerivative = 40,
+    [Parameter(Mandatory = $false)][double]$WeightingFactorForSihouetteScore = 18,
+    [Parameter(Mandatory = $false)][double]$WeightingFactorForDaviesBouldinScore = 13,
     [Parameter(Mandatory = $false)][double]$WeightingFactorForCalinskiHarabaszScore = 12
 )
 


### PR DESCRIPTION
I have the script performing k-means clustering for a varying number of clusters, from 1 to n, where n is the square root of the number of items in the data set plus 20%, rounded up to the nearest integer.

For each k-means clustering operation, I implemented the elbow method (second derivative of the within-cluster sum of squares) plus the calculation of the silhouette score, Davies-Bouldin Index, and Calinski-Harabasz Index. These get compiled and passed along as the key statistics.

Weighting is applied to each statistic, and the script uses them to select the ideal number of clusters to use in the k-means clustering operation. It outputs the corresponding cluster metadata to a CSV. Optionally (and recommended), it will output the cluster statistics and metadata for each k-means clustering operation to an Excel workbook.

I also made other quality-of-life improvements, like outputting better information to the information stream, and I issued warnings if the script is calculating the ideal number of clusters but not using the extended statistics (silhouette score, DBI, CHI) to help make the decision, especially if the user is not outputting the clustering statistics for review. The script will also output a warning if the script detects poor clustering results, which can sometimes happen with evenly dispersed datasets.